### PR TITLE
docs : "Google Analytics" Fix

### DIFF
--- a/docs/en/guide/config.md
+++ b/docs/en/guide/config.md
@@ -1264,6 +1264,8 @@ live_time:
   start_time: "2019-04-12T00: 00: 00"
 ```
 
+> Remember to add 0, such as `2019-04-01` instead of `2019-4-1`.
+
 ### Custom Text
 
 `custom_text` is a custom footer and can contain HTML.
@@ -1288,7 +1290,6 @@ Randomly display a sentence on the homepage of the website ~~eighth-grade syndro
 say:
   enable: true
   api: https://cdn.jsdelivr.net/gh/ElpsyCN/say@gh-pages/sentences.json
-  src: /js/say.js
   # https://developer.hitokoto.cn/sentence/
   hitokoto:
     enable: true

--- a/docs/en/guide/third-party-support.md
+++ b/docs/en/guide/third-party-support.md
@@ -253,6 +253,7 @@ Go to [Google Analytics](https://analytics.google.com/) to get your ID. (Science
 google_analytics:
   enable: true
   id: UA-XXXXXXXXX-X
+  // Note : Google Analytics abandoned the measurement ID of "UA-XXXXXXXXX-X" and used the measurement ID of "G-XXXXXXXXXX". You can fill in the new measurement ID directly in the "id:" item, which will not affect the analysis .
 ```
 
 ### busuanzi

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -1292,6 +1292,8 @@ footer:
     start_time: "2019-04-12T00:00:00"
 ```
 
+> 注意记得补 0，譬如 `2019-04-01` 而不是 `2019-4-1`。
+
 ### 自定义文本
 
 `custom_text` 为自定义页脚，可以包含 HTML。
@@ -1366,7 +1368,6 @@ say:
 say:
   enable: true
   api: /data/sentences.json
-  src: /js/say.js
   hitokoto:
     enable: false
 ```
@@ -1389,6 +1390,8 @@ mourn:
   days:
     - "4-4"
 ```
+
+> 注意这里不用补 0，因为直接获取月日判断时，可以直接判断，逻辑代码最少。
 
 ## 自定义样式
 

--- a/docs/guide/third-party-support.md
+++ b/docs/guide/third-party-support.md
@@ -165,7 +165,7 @@ Valine 的扩展和增强功能可以参考 [Valine-Admin](https://github.com/De
 
 ### MiniValine
 
-A simple and minimalist comment system based on Leancloud.
+简单且简约的评论系统，基于LeanCloud。
 
 - GitHub: [MiniValine](https://github.com/MiniValine/MiniValine)
 - Demo: <https://minivaline.github.io/>
@@ -290,6 +290,7 @@ algolia_search:
 google_analytics:
   enable: true
   id: UA-XXXXXXXXX-X
+  // 注意：最近新建的谷歌分析账号ID已经修改，格式如：G-XXXXXXXXXX，可以直接填入id一项，功能正常。
 ```
 
 ### busuanzi


### PR DESCRIPTION
最近进行大更新，所以对谷歌分析进行重建。
当建立新账号后，发现原来的UA-开头的ID被弃用，转而使用了G-XXXXXXXXXX形式的ID
但文档中没有写明，容易造成误导，故进行标注